### PR TITLE
we should use binread for reading binary data

### DIFF
--- a/lib/mime/types.rb
+++ b/lib/mime/types.rb
@@ -849,7 +849,7 @@ module MIME
 
     cache_file = File.expand_path("../types.marshal-data", __FILE__)
     if File.exist?(cache_file)
-      @__types__ = Marshal.load(File.read(cache_file))
+      @__types__ = Marshal.load(File.binread(cache_file))
     else
       files = Dir[File.join(File.dirname(__FILE__), 'types', '*')]
       MIME::Types::STARTUP = true unless $DEBUG


### PR DESCRIPTION
We're seeing needles in production because `File.read` will try to transcode the binary marshal data.  We should be using `binread` because Marshal data is binary.
